### PR TITLE
Support erb in config file && allow silent branch-failure

### DIFF
--- a/lib/gemnasium.rb
+++ b/lib/gemnasium.rb
@@ -14,7 +14,13 @@ module Gemnasium
       @config = load_config(options[:project_path])
 
       unless current_branch == @config.project_branch
-        quit_because_of("Gemnasium : Dependency files updated but not on tracked branch (#{@config.project_branch}), ignoring...\n")
+        message = "Gemnasium : Dependency files updated but not on tracked branch (#{@config.project_branch}), ignoring...\n"
+        if options[:silent_branch]
+          notify message, :blue
+          return
+        else
+          quit_because_of(message)
+        end
       end
 
       dependency_files_hashes = DependencyFiles.get_sha1s_hash(options[:project_path])

--- a/lib/gemnasium/configuration.rb
+++ b/lib/gemnasium/configuration.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'erb'
 
 module Gemnasium
   class Configuration
@@ -14,7 +15,7 @@ module Gemnasium
     def initialize config_file
       raise Errno::ENOENT, "Configuration file (#{config_file}) does not exist.\nPlease run `gemnasium install`." unless File.file?(config_file)
 
-      config_hash = DEFAULT_CONFIG.merge!(YAML.load_file(config_file))
+      config_hash = DEFAULT_CONFIG.merge!(YAML.load(ERB.new(File.read(config_file)).result))
       config_hash.each do |k, v|
         writer_method = "#{k}="
         if respond_to?(writer_method)

--- a/lib/gemnasium/options.rb
+++ b/lib/gemnasium/options.rb
@@ -62,6 +62,10 @@ See `gemnasium COMMAND --help` for more information on a specific command.
         'push'    => OptionParser.new do |opts|
           opts.banner = 'Usage: gemnasium push'
 
+          opts.on '--silent-branch', 'Ignore untracked branches' do
+            options[:silent_branch] = true
+          end
+
           opts.on '-h', '--help', 'Display this message' do
             options[:show_help] = true
           end

--- a/spec/gemnasium/options_spec.rb
+++ b/spec/gemnasium/options_spec.rb
@@ -104,6 +104,13 @@ describe Gemnasium::Options do
             expect(options).to eql({ command: 'push' })
           end
         end
+
+        context 'with silent branch options' do
+          it 'correctly set the options' do
+            options, parser = Gemnasium::Options.parse ['push', '--silent-branch']
+            expect(options).to eql({ command: 'push', silent_branch: true })
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Allows injection of API key from environment using

```
<%= ENV['GEMNASIUM_API_KEY'] %>
```

If you want the config file versioned.

Also allows you to prevent an error-return if the current branch is not the specified gemnasium one.
