### PR TITLE
tests: only check Gemfile.lock if it exists

### DIFF
--- a/spec/gemnasium/dependency_files_spec.rb
+++ b/spec/gemnasium/dependency_files_spec.rb
@@ -35,7 +35,9 @@ describe Gemnasium::DependencyFiles do
         sha1s_hash = Gemnasium::DependencyFiles.get_sha1s_hash(project_path)
 
         expect(sha1s_hash).to have_key(subdir_file_path)
-        expect(sha1s_hash).to have_key('Gemfile.lock')
+        if File.exists?('Gemfile.lock')
+          expect(sha1s_hash).to have_key('Gemfile.lock')
+        end
       end
 
       context 'which is ignored' do


### PR DESCRIPTION
I'm working on packaging gemnasium for Fedora, and we run the rspec tests as part of the build. I found a test failure, and I hope you'll consider accepting this pull request.

The test suite assumes that Gemfile.lock exists. However, the gemnasium gem file on RubyGems.org does not contain a Gemfile.lock. This pull request will cause the test suite to skip the test if the Gemfile.lock file does not exist.
