### PR TITLE
Add an --ignore-branch option for 'gemnasium push'

### DIFF
--- a/lib/gemnasium.rb
+++ b/lib/gemnasium.rb
@@ -15,7 +15,12 @@ module Gemnasium
       ensure_config_is_up_to_date!
 
       unless current_branch == @config.project_branch
-        quit_because_of("Dependency files updated but not on tracked branch (#{@config.project_branch}), ignoring...\n")
+        message = "Dependency files updated but not on tracked branch (#{@config.project_branch}), ignoring...\n"
+        if options[:ignore_branch]
+          notify message, :blue
+        else
+          quit_because_of(message)
+        end
       end
 
       unless has_project_slug?

--- a/lib/gemnasium/options.rb
+++ b/lib/gemnasium/options.rb
@@ -60,6 +60,10 @@ See `gemnasium COMMAND --help` for more information on a specific command.
         'push'    => OptionParser.new do |opts|
           opts.banner = 'Usage: gemnasium push'
 
+          opts.on '--ignore-branch', 'Ignore untracked branches' do
+            options[:ignore_branch] = true
+          end
+
           opts.on '-h', '--help', 'Display this message' do
             options[:show_help] = true
           end

--- a/spec/gemnasium/options_spec.rb
+++ b/spec/gemnasium/options_spec.rb
@@ -97,6 +97,13 @@ describe Gemnasium::Options do
             expect(options).to eql({ command: 'push' })
           end
         end
+        
+        context 'with ignore branch options' do
+          it 'correctly set the options' do
+            options, parser = Gemnasium::Options.parse ['push', '--ignore-branch']
+            expect(options).to eql({ command: 'push', ignore_branch: true })
+          end
+        end
       end
 
       context '`migrate`' do

--- a/spec/gemnasium_spec.rb
+++ b/spec/gemnasium_spec.rb
@@ -51,6 +51,21 @@ describe Gemnasium do
           expect(error_output).to include "Dependency files updated but not on tracked branch (master), ignoring...\n"
         }
       end
+
+      context 'with supported dependency files for gemnasium project not up-to-date' do
+        let(:sha1_hash) {{ 'new_gemspec.gemspec' => 'gemspec_sha1_hash', 'modified_lockfile.lock' => 'lockfile_sha1_hash', 'Gemfile_unchanged.lock' => 'gemfile_sha1_hash' }}
+        let(:hash_to_upload) {[{ filename: 'new_gemspec.gemspec', sha: 'gemspec_sha1_hash', content: 'stubbed gemspec content' },
+                              { filename: 'modified_lockfile.lock', sha: 'lockfile_sha1_hash', content: 'stubbed lockfile content' }]}
+
+        before do
+          Gemnasium::DependencyFiles.stub(:get_sha1s_hash).and_return(sha1_hash)
+          Gemnasium::DependencyFiles.stub(:get_content_to_upload).and_return(hash_to_upload)
+        end
+
+        it 'should not quit the program when :ignore_branch is true' do
+          expect{ Gemnasium.push({ project_path: project_path, ignore_branch: true }) }.to_not raise_error
+        end
+      end
     end
 
     context 'on the tracked branch' do


### PR DESCRIPTION
Mostly copied from https://github.com/gemnasium/gemnasium-gem/pull/4, but renamed and including the additional requested spec. I've also tested this locally w/ a project and ensured that Gemfiles were pushed to Gemnasium regardless of branch when the ignore-branch flag is used.

The motivation for this is that we run `gemnasium push` on our Jenkins server and it's running the tests in a detached branch. For example, one of our jobs' `current_branch` value is "(detached from 8e1a2b8)"). This is preventing us from keeping our gems up to date on Gemnasium.

Please let me know if there's anything else needed for a merge.
