### PR TITLE
Don't raise error when pushing from an ignored branch

### DIFF
--- a/lib/gemnasium.rb
+++ b/lib/gemnasium.rb
@@ -14,13 +14,9 @@ module Gemnasium
       @config = load_config(options[:project_path])
       ensure_config_is_up_to_date!
 
-      unless current_branch == @config.project_branch
-        message = "Dependency files updated but not on tracked branch (#{@config.project_branch}), ignoring...\n"
-        if options[:ignore_branch]
-          notify message, :blue
-        else
-          quit_because_of(message)
-        end
+      unless current_branch == @config.project_branch || options[:ignore_branch]
+        notify "Dependency files updated but not on tracked branch (#{@config.project_branch}).\n", :blue
+        return
       end
 
       unless has_project_slug?

--- a/spec/gemnasium_spec.rb
+++ b/spec/gemnasium_spec.rb
@@ -45,13 +45,6 @@ describe Gemnasium do
     context 'on a non tracked branch' do
       before { allow(Gemnasium).to receive(:current_branch).and_return('non_project_branch') }
 
-      it 'quit the program' do
-        expect{ Gemnasium.push({ project_path: project_path }) }.to raise_error { |e|
-          expect(e).to be_kind_of SystemExit
-          expect(error_output).to include "Dependency files updated but not on tracked branch (master), ignoring...\n"
-        }
-      end
-
       context 'with supported dependency files for gemnasium project not up-to-date' do
         let(:sha1_hash) {{ 'new_gemspec.gemspec' => 'gemspec_sha1_hash', 'modified_lockfile.lock' => 'lockfile_sha1_hash', 'Gemfile_unchanged.lock' => 'gemfile_sha1_hash' }}
         let(:hash_to_upload) {[{ filename: 'new_gemspec.gemspec', sha: 'gemspec_sha1_hash', content: 'stubbed gemspec content' },
@@ -62,8 +55,16 @@ describe Gemnasium do
           allow(Gemnasium::DependencyFiles).to receive(:get_content_to_upload).and_return(hash_to_upload)
         end
 
-        it 'should not quit the program when :ignore_branch is true' do
-          expect{ Gemnasium.push({ project_path: project_path, ignore_branch: true }) }.to_not raise_error
+        it 'should not contact Gemnasium' do
+          Gemnasium.push({ project_path: project_path })
+          expect(WebMock).to_not have_requested(:post, api_url('/api/v3/projects/existing-slug/dependency_files/compare'))
+        end
+
+        context "when :ignore_branch is true" do
+          it 'should still contact Gemnasium' do
+            Gemnasium.push({ project_path: project_path, ignore_branch: true })
+            expect(WebMock).to have_requested(:post, api_url('/api/v3/projects/existing-slug/dependency_files/compare'))
+          end
         end
       end
     end


### PR DESCRIPTION
At the moment, if the `ignore_branch` option is set to `true` the user will be notified that they're on the ignored branch, but the push method will continue executing regardless.
