### PR TITLE
Clearer doc for the ignore-branch option

### DIFF
--- a/lib/gemnasium/options.rb
+++ b/lib/gemnasium/options.rb
@@ -60,7 +60,7 @@ See `gemnasium COMMAND --help` for more information on a specific command.
         'push'    => OptionParser.new do |opts|
           opts.banner = 'Usage: gemnasium push'
 
-          opts.on '--ignore-branch', 'Ignore untracked branches' do
+          opts.on '-i', '--ignore-branch', 'Push to gemnasium regardless of branch' do
             options[:ignore_branch] = true
           end
 


### PR DESCRIPTION
That. The `ignore_branch` option will ignore the branch you specify as `project_branch` and push changes to gemnasium regardless of the branch you're on.
