### PR TITLE
Add silence-ignored-branches option

### DIFF
--- a/lib/gemnasium.rb
+++ b/lib/gemnasium.rb
@@ -15,11 +15,13 @@ module Gemnasium
       ensure_config_is_up_to_date!
 
       unless current_branch == @config.project_branch
-        message = "Dependency files updated but not on tracked branch (#{@config.project_branch}), ignoring...\n"
         if options[:ignore_branch]
-          notify message, :blue
+          notify "Not on tracked branch (#{@config.project_branch}), but ignore-branch option set to true. Continuing.\n", :blue
+        elsif options[:silence_branch]
+          notify "Not on tracked branch (#{@config.project_branch}). Exiting silently.\n", :blue
+          return
         else
-          quit_because_of(message)
+          quit_because_of("Not on tracked branch (#{@config.project_branch})")
         end
       end
 

--- a/lib/gemnasium/options.rb
+++ b/lib/gemnasium/options.rb
@@ -64,6 +64,10 @@ See `gemnasium COMMAND --help` for more information on a specific command.
             options[:ignore_branch] = true
           end
 
+          opts.on '-s', '--silence-branch', 'Silently ignore untracked branches' do
+            options[:silence_branch] = true
+          end
+
           opts.on '-h', '--help', 'Display this message' do
             options[:show_help] = true
           end

--- a/spec/gemnasium/options_spec.rb
+++ b/spec/gemnasium/options_spec.rb
@@ -97,11 +97,18 @@ describe Gemnasium::Options do
             expect(options).to eql({ command: 'push' })
           end
         end
-        
+
         context 'with ignore branch options' do
           it 'correctly set the options' do
             options, parser = Gemnasium::Options.parse ['push', '--ignore-branch']
             expect(options).to eql({ command: 'push', ignore_branch: true })
+          end
+        end
+
+        context 'with silence branch failure options' do
+          it 'correctly set the options' do
+            options, parser = Gemnasium::Options.parse ['push', '--silence-branch']
+            expect(options).to eql({ command: 'push', silence_branch: true })
           end
         end
       end


### PR DESCRIPTION
Adds a `silence-ignored-branches` option to `gemnasium push`. If enabled, a push from an untracked branch will notify and no-op, as opposed to erroring.
