### PR TITLE
Add Ruby 2.1.2 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.2


### PR DESCRIPTION
Would be great to know Ruby 2.1.2 is supported.
